### PR TITLE
chore: add package metadata, READMEs, and npm v0.0.5

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,1 +1,0 @@
-# No environment variables required for now

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,58 @@
+# @modelpedia/api
+
+REST API for [api.modelpedia.dev](https://api.modelpedia.dev) — query AI model data programmatically.
+
+## Stack
+
+- [Hono](https://hono.dev) on [Cloudflare Workers](https://workers.cloudflare.com)
+
+## Development
+
+From the monorepo root:
+
+```bash
+pnpm dev:api
+```
+
+Or from this directory:
+
+```bash
+pnpm dev
+```
+
+The dev server starts at `http://localhost:8787`.
+
+## Deployment
+
+```bash
+pnpm deploy
+```
+
+Deploys to Cloudflare Workers via [Wrangler](https://developers.cloudflare.com/workers/wrangler/).
+
+## Endpoints
+
+All endpoints are under the `/v1` prefix.
+
+| Path | Description |
+|------|-------------|
+| `/stats` | Aggregate statistics |
+| `/providers` | List all providers |
+| `/providers/compare` | Compare providers |
+| `/providers/:id` | Get provider details |
+| `/models` | List all models (with filtering) |
+| `/models/compare` | Compare models |
+| `/models/latest` | Recently added models |
+| `/models/recommend` | Model recommendations |
+| `/models/types` | List model types |
+| `/models/:provider/:id` | Get model details |
+| `/creators` | List model creators |
+| `/pricing/compare` | Compare pricing |
+| `/capabilities` | List capabilities |
+| `/modalities` | List modalities |
+| `/tools` | List tools |
+| `/search` | Search models |
+| `/families` | List model families |
+| `/export` | Export all data |
+
+See [API docs](https://modelpedia.dev/docs/api) for full details.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "description": "api.modelpedia.dev — REST API on Cloudflare Workers",
+  "author": "AgentbaseAI Inc.",
   "license": "MIT",
+  "homepage": "https://modelpedia.dev",
+  "bugs": {
+    "url": "https://github.com/assistant-ui/modelpedia/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/assistant-ui/modelpedia",
+    "directory": "apps/api"
+  },
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,0 @@
-# ── Auth (OIDC via accounts.assistant-ui.com) ──
-NEXT_PUBLIC_AUTH_URL=https://accounts.assistant-ui.com
-OIDC_CLIENT_ID=modelpedia
-AUTH_SECRET=your-secret-key-min-32-chars-here

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,54 @@
+# @modelpedia/web
+
+Next.js website for [modelpedia.dev](https://modelpedia.dev) — browse and compare AI models across providers.
+
+## Stack
+
+- [Next.js](https://nextjs.org) 16 (App Router, Turbopack)
+- [React](https://react.dev) 19
+- [Tailwind CSS](https://tailwindcss.com) 4
+- [Vercel](https://vercel.com) for deployment
+
+## Development
+
+From the monorepo root:
+
+```bash
+pnpm dev:web
+```
+
+Or from this directory:
+
+```bash
+pnpm dev
+```
+
+The dev server starts at `http://localhost:3000`.
+
+## Build
+
+```bash
+pnpm build
+```
+
+## Project Structure
+
+```
+app/
+  page.tsx                 → Homepage
+  [provider]/              → Provider detail pages
+  [provider]/[...id]/      → Model detail pages
+  models/                  → All models listing
+  compare/                 → Model comparison
+  changes/                 → Data change log
+  analytics/               → Analytics dashboard
+  api/                     → API routes (OG images, markdown)
+components/
+  pages/                   → Page-specific components
+  shared/                  → Shared components (search, model list, etc.)
+  ui/                      → Base UI components
+lib/
+  data.ts                  → Data access layer
+  search.ts                → Search utilities
+  sort.ts                  → Sorting utilities
+```

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "description": "modelpedia.dev — browse and compare AI models across providers",
+  "author": "AgentbaseAI Inc.",
   "license": "MIT",
+  "homepage": "https://modelpedia.dev",
+  "bugs": {
+    "url": "https://github.com/assistant-ui/modelpedia/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/assistant-ui/modelpedia",
+    "directory": "apps/web"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,0 +1,33 @@
+# @modelpedia/data
+
+Core data package — model definitions, fetch scripts, validation, and code generation.
+
+## Structure
+
+```
+providers/
+  <provider>/
+    provider.json          → Provider metadata
+    models/*.json          → Individual model definitions
+    overrides.json         → Manual overrides (protected from auto-fetch)
+scripts/
+  fetch-<provider>.ts     → Auto-fetch from provider APIs
+  generate.ts             → Generate TypeScript from JSON
+  validate.ts             → Data integrity checks
+  detect-changes.ts       → Track model data changes
+src/
+  index.ts                → Exported data access API
+```
+
+## Commands
+
+```bash
+pnpm generate             # Regenerate data.ts from JSON files
+pnpm validate             # Validate all model data
+pnpm fetch:all            # Fetch latest from all provider APIs
+pnpm fetch:<provider>     # Fetch from a specific provider
+```
+
+## Adding Data
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on adding or updating providers and models.

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -46,6 +46,10 @@
     "fetch:all": "bun run fetch:openai && bun run fetch:anthropic && bun run fetch:google && bun run fetch:mistral && bun run fetch:deepseek && bun run fetch:xai && bun run fetch:cohere && bun run fetch:zai && bun run fetch:minimax && bun run fetch:alibaba && bun run fetch:meta && bun run fetch:moonshot && bun run fetch:cerebras && bun run fetch:baseten && bun run fetch:openrouter && bun run fetch:perplexity && bun run fetch:azure && bun run fetch:groq && bun run fetch:nvidia && bun run fetch:together && bun run fetch:fireworks && bun run fetch:amazon && bun run fetch:vercel && bun run fetch:vertex && bun run fetch:cloudflare-workers-ai && bun run fetch:cloudflare-ai-gateway && bun run fetch:opencode && bun run fetch:ollama && bun run fetch:huggingface && bun run fetch:qwen && bun run fetch:cursor"
   },
   "author": "AgentbaseAI Inc.",
+  "homepage": "https://modelpedia.dev",
+  "bugs": {
+    "url": "https://github.com/assistant-ui/modelpedia/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/assistant-ui/modelpedia",

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -25,7 +25,7 @@ import {
   getModelsByCreator,
 } from "modelpedia";
 
-// All models (2000+)
+// All models (4000+)
 console.log(allModels.length);
 
 // Find a specific model
@@ -95,7 +95,6 @@ Available: `modelpedia/openai`, `modelpedia/anthropic`, `modelpedia/google`, `mo
 | `speed` | `number?` | Speed rating (1-5) |
 | `architecture` | `string?` | Model architecture (`transformer`, `moe`, `ssm`, `hybrid`) |
 | `open_weight` | `boolean?` | Whether model weights are publicly available |
-| `api_compatibility` | `string[]?` | Compatible API formats (e.g. `["openai"]`) |
 | `license` | `string?` | SPDX ID, custom name, or `"proprietary"` |
 | `parameters` | `number?` | Total parameters in billions |
 | `active_parameters` | `number?` | Active parameters for MoE models |
@@ -131,7 +130,7 @@ model.pricing?.tiers  // PricingTier[] — text tokens, audio tokens, image gene
 
 ## Providers
 
-Alibaba Cloud, Amazon Bedrock, Anthropic, Azure, Baseten, Cerebras, Cloudflare, Cohere, Cursor, DeepSeek, Fireworks, Google, Groq, Hugging Face, Meta, Minimax, Mistral, Moonshot, NVIDIA, Ollama, OpenAI, OpenCode, OpenRouter, Perplexity, Qwen, Together AI, Vercel, Vertex AI, xAI, Z.AI, and more.
+Alibaba Cloud, Amazon Bedrock, Anthropic, Azure, Baseten, Cerebras, Cloudflare (Workers AI, AI Gateway), Cohere, Cursor, DeepSeek, Fireworks, Google, Groq, Hugging Face, Meta, Minimax, Mistral, Moonshot, NVIDIA, Ollama, OpenAI, OpenCode, OpenRouter, Perplexity, Qwen, Together AI, Vercel, Vertex AI, xAI, and Z.AI.
 
 ## Data Updates
 

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelpedia",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Open catalog of AI model data — specs, pricing, and capabilities across 30+ providers and 4000+ models",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,13 @@
+# @modelpedia/tsconfig
+
+Shared TypeScript configurations for the modelpedia monorepo.
+
+## Usage
+
+Extend in your package's `tsconfig.json`:
+
+```json
+{
+  "extends": "@modelpedia/tsconfig/base.json"
+}
+```

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,7 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "description": "Shared TypeScript configurations for modelpedia",
+  "author": "AgentbaseAI Inc.",
   "license": "MIT",
+  "homepage": "https://modelpedia.dev",
+  "bugs": {
+    "url": "https://github.com/assistant-ui/modelpedia/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/assistant-ui/modelpedia",
+    "directory": "packages/tsconfig"
+  },
   "files": [
     "*.json"
   ]


### PR DESCRIPTION
## Summary

- Add author, homepage, bugs, and repository fields to package.json across apps and packages
- Remove unused .env.example files from apps/api and apps/web
- Add README files for apps/api, apps/web, packages/data, and packages/tsconfig
- Bump @modelpedia/models to v0.0.5 and update README (4000+ models, refined provider list, remove deprecated api_compatibility field)
- Fix next-env.d.ts routes type path for Next.js compatibility

## Test plan

- [ ] Verify package.json metadata renders correctly on npm/GitHub
- [ ] Confirm no .env.example references remain in docs or scripts
- [ ] Review README content for accuracy
- [ ] Verify npm package publishes correctly at v0.0.5
- [ ] Confirm web app builds without next-env.d.ts type errors