### PR TITLE
fix: CI fetch workflow checkout conflict and heatmap missing border

### DIFF
--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -84,17 +84,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Determine default branch
-          DEFAULT_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: //p')
-
-          # Check if branch already exists on remote
-          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            git reset --hard "origin/$DEFAULT_BRANCH"
-          else
-            git checkout -b "$BRANCH"
-          fi
+          # Create or reset branch from current HEAD (which is default branch + fetched data)
+          git checkout -B "$BRANCH"
 
           git add packages/data/providers packages/data/src/data.ts
           git commit -m "data: update model data $(date +%Y-%m-%d)"

--- a/apps/web/components/pages/analytics/capability-heatmap.tsx
+++ b/apps/web/components/pages/analytics/capability-heatmap.tsx
@@ -39,9 +39,9 @@ export function CapabilityHeatmap({
   const caps = Object.keys(CAP_LABELS);
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-hidden overflow-x-auto rounded-md ring-1 ring-border">
       <div
-        className="grid gap-px overflow-hidden rounded-md bg-border ring-1 ring-border"
+        className="grid gap-px bg-border"
         style={{
           gridTemplateColumns: `1fr repeat(${caps.length}, 4rem)`,
         }}


### PR DESCRIPTION
## Summary
- **CI**: Replace fetch+checkout+reset branch strategy with `git checkout -B` in fetch-models workflow — the fetch scripts produce uncommitted changes that block `git checkout` to the update branch
- **Web**: Move `ring-1`, `rounded-md`, and `overflow-hidden` from the inner grid to the outer wrapper in the capability heatmap so the border is not clipped by `overflow-x-auto` and corners render correctly

## Test plan
- [ ] Trigger fetch-models workflow manually and verify it completes without checkout errors
- [ ] Verify the capability heatmap on `/analytics` shows outer border with rounded corners