### PR TITLE
fix(ci): summarize changes in PR body instead of raw dump

### DIFF
--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -91,17 +91,25 @@ jobs:
           git commit -m "data: update model data $(date +%Y-%m-%d)"
           git push origin "$BRANCH" --force
 
-          SUMMARY=$(cd packages/data && bun run changes -- HEAD~1 --dry-run 2>&1 | head -200)
+          # Build a short summary: count creates/updates/deletes per provider
+          RAW=$(cd packages/data && bun run changes -- HEAD~1 --dry-run 2>&1)
+          STATS=$(echo "$RAW" | grep -E '^\s+(created|updated|deleted):' || true)
+          PROVIDERS=$(echo "$RAW" | grep -cE '^\s+[+Δ-] ' || true)
+          SUMMARY="**${PROVIDERS} model changes** on $(date +%Y-%m-%d)"
+          if [ -n "$STATS" ]; then
+            SUMMARY="${SUMMARY}"$'\n\n'"$(echo "$STATS" | sed 's/^  /- /')"
+          fi
 
           # Create PR if none exists, otherwise update the existing one
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          BODY=$(printf '## Automated model data update\n\n%s\n\n> Auto-created by the fetch-models workflow.\n> Changes will be detected on merge.' "$SUMMARY")
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "data: update model data $(date +%Y-%m-%d)" \
-              --body "$(printf '## Automated model data update\n\n```\n%s\n```\n\n> Auto-created by the fetch-models workflow.\n> Changes will be detected on merge.' "$SUMMARY")"
+              --body "$BODY"
             echo "Updated PR #$EXISTING_PR"
           else
             gh pr create \
               --title "data: update model data $(date +%Y-%m-%d)" \
-              --body "$(printf '## Automated model data update\n\n```\n%s\n```\n\n> Auto-created by the fetch-models workflow.\n> Changes will be detected on merge.' "$SUMMARY")"
+              --body "$BODY"
           fi

--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -91,7 +91,7 @@ jobs:
           git commit -m "data: update model data $(date +%Y-%m-%d)"
           git push origin "$BRANCH" --force
 
-          SUMMARY=$(cd packages/data && bun run changes -- HEAD~1 --dry-run 2>&1)
+          SUMMARY=$(cd packages/data && bun run changes -- HEAD~1 --dry-run 2>&1 | head -200)
 
           # Create PR if none exists, otherwise update the existing one
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,13 +27,13 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.0.1",
     "next": "catalog:",
     "next-themes": "^0.4.6",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-simple-maps": "^3.0.0",
-    "sugar-high": "^0.9.5",
+    "sugar-high": "^1.0.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     hono:
-      specifier: ^4.12.8
-      version: 4.12.8
+      specifier: ^4.12.9
+      version: 4.12.9
     next:
       specifier: ^16.2.1
       version: 16.2.1
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^4.2.2
       version: 4.2.2
     typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
+      specifier: ^6.0.2
+      version: 6.0.2
     wrangler:
       specifier: ^4.76.0
       version: 4.76.0
@@ -67,7 +67,7 @@ importers:
     dependencies:
       '@hono/mcp':
         specifier: ^0.2.4
-        version: 0.2.4(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.8))(hono@4.12.8)(zod@4.3.6)
+        version: 0.2.4(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.9))(hono@4.12.9)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
@@ -76,7 +76,7 @@ importers:
         version: link:../../packages/data
       hono:
         specifier: 'catalog:'
-        version: 4.12.8
+        version: 4.12.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -109,8 +109,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.4)
+        specifier: ^1.0.1
+        version: 1.0.1(react@19.2.4)
       next:
         specifier: 'catalog:'
         version: 16.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -127,8 +127,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(prop-types@15.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sugar-high:
-        specifier: ^0.9.5
-        version: 0.9.5
+        specifier: ^1.0.0
+        version: 1.0.0
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -156,22 +156,22 @@ importers:
         version: 4.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.2
 
   packages/data:
     devDependencies:
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.2
 
   packages/npm:
     devDependencies:
       tsdown:
         specifier: ^0.21.4
-        version: 0.21.4(typescript@5.9.3)
+        version: 0.21.4(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.2
 
   packages/tsconfig: {}
 
@@ -1669,8 +1669,8 @@ packages:
     peerDependencies:
       hono: ^4.1.1
 
-  hono@4.12.8:
-    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -1860,8 +1860,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.0.1:
+    resolution: {integrity: sha512-lih7tKEczCYOQjVEzpFuxEuNzlwf+1yhvlMlEkGWJM3va8Pugv8bYXc/pRtcjPncaP7k84X0Pt/71ufxvqEPtQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -2250,8 +2250,8 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  sugar-high@0.9.5:
-    resolution: {integrity: sha512-eirwp9p7QcMg6EFCD6zrGh4H30uFx2YtfiMJUavagceP6/YUUjLeiQmis7QuwqKB3nXrWXlLaRumCqOd9AKpSA==}
+  sugar-high@1.0.0:
+    resolution: {integrity: sha512-QXI5DHWxBI4kph38jBgfq0a8859NxA1fZMpkbiUmd332/SMdBKOQ+8f6gdCfEWg0ZY2216Oh8OqS5lC0IOTQmA==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -2329,8 +2329,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2675,17 +2675,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/mcp@0.2.4(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.8))(hono@4.12.8)(zod@4.3.6)':
+  '@hono/mcp@0.2.4(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.9))(hono@4.12.9)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
-      hono: 4.12.8
-      hono-rate-limiter: 0.4.2(hono@4.12.8)
+      hono: 4.12.9
+      hono-rate-limiter: 0.4.2(hono@4.12.9)
       pkce-challenge: 5.0.1
       zod: 4.3.6
 
-  '@hono/node-server@1.19.11(hono@4.12.8)':
+  '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
-      hono: 4.12.8
+      hono: 4.12.9
 
   '@img/colour@1.1.0': {}
 
@@ -2811,7 +2811,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.8)
+      '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2821,7 +2821,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
+      hono: 4.12.9
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3637,11 +3637,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono-rate-limiter@0.4.2(hono@4.12.8):
+  hono-rate-limiter@0.4.2(hono@4.12.9):
     dependencies:
-      hono: 4.12.8
+      hono: 4.12.9
 
-  hono@4.12.8: {}
+  hono@4.12.9: {}
 
   hookable@6.1.0: {}
 
@@ -3787,7 +3787,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lucide-react@0.577.0(react@19.2.4):
+  lucide-react@1.0.1(react@19.2.4):
     dependencies:
       react: 19.2.4
 
@@ -4015,7 +4015,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -4028,7 +4028,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.9
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -4217,7 +4217,7 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
-  sugar-high@0.9.5: {}
+  sugar-high@1.0.0: {}
 
   supports-color@10.2.2: {}
 
@@ -4244,7 +4244,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.21.4(typescript@5.9.3):
+  tsdown@0.21.4(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -4255,7 +4255,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.9
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.9)(typescript@6.0.2)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -4263,7 +4263,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.32
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -4288,7 +4288,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   unconfig-core@7.5.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,14 +13,14 @@ catalog:
   react-grab: ^0.1.28
 
   # TypeScript
-  typescript: ^5.9.3
+  typescript: ^6.0.2
 
   # Tailwind CSS
   tailwindcss: ^4.2.2
   "@tailwindcss/postcss": ^4.2.2
 
   # Hono
-  hono: ^4.12.8
+  hono: ^4.12.9
 
   # Cloudflare
   wrangler: ^4.76.0


### PR DESCRIPTION
## Summary
- Replace raw `changes --dry-run` output (can be thousands of lines) with a short summary: total change count + created/updated/deleted stats
- Fixes `Body is too long (maximum is 65536 characters)` error when many models are updated

## Test plan
- [ ] Trigger fetch-models workflow manually and verify PR body shows a clean summary like "**842 model changes** on 2026-03-23\n- created: 5 models\n- updated: 837 models"