### PR TITLE
refactor: optimize API dedup, lazy-load CommandPalette, split sitemap

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,16 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { prettyJSON } from "hono/pretty-json";
 import { handleMcp } from "./mcp";
+import {
+  aggregateByKey,
+  aggregateCapabilities,
+  aggregateFamilies,
+  comparePricing,
+  filterModels,
+  type SortField,
+  searchAll,
+  sortModels,
+} from "./query";
 
 type Env = {
   Bindings: {
@@ -165,64 +175,19 @@ app.get("/providers/:id", (c) => {
 // ── GET /v1/models ──
 
 app.get("/models", (c) => {
-  let models: Model[] = [...allModels];
+  const models = filterModels([...allModels], {
+    provider: c.req.query("provider"),
+    family: c.req.query("family"),
+    creator: c.req.query("creator"),
+    status: c.req.query("status"),
+    capability: c.req.query("capability"),
+    q: c.req.query("q"),
+  });
 
-  const provider = c.req.query("provider");
-  if (provider) models = models.filter((m) => m.provider === provider);
-
-  const family = c.req.query("family");
-  if (family) models = models.filter((m) => m.family === family);
-
-  const creator = c.req.query("creator");
-  if (creator) models = models.filter((m) => m.created_by === creator);
-
-  const status = c.req.query("status");
-  if (status) models = models.filter((m) => m.status === status);
-
-  const capability = c.req.query("capability");
-  if (capability) {
-    models = models.filter(
-      (m) => m.capabilities?.[capability as keyof typeof m.capabilities],
-    );
-  }
-
-  const q = c.req.query("q")?.toLowerCase();
-  if (q) {
-    models = models.filter(
-      (m) =>
-        m.id.toLowerCase().includes(q) ||
-        m.name.toLowerCase().includes(q) ||
-        m.description?.toLowerCase().includes(q) ||
-        m.family?.toLowerCase().includes(q) ||
-        m.created_by?.toLowerCase().includes(q),
-    );
-  }
-
-  // Sort
-  const sort = c.req.query("sort");
-  const order = c.req.query("order") === "desc" ? -1 : 1;
+  const sort = c.req.query("sort") as SortField | undefined;
   if (sort) {
-    models.sort((a, b) => {
-      let va: number | string | undefined;
-      let vb: number | string | undefined;
-      if (sort === "price_input") {
-        va = a.pricing?.input ?? undefined;
-        vb = b.pricing?.input ?? undefined;
-      } else if (sort === "price_output") {
-        va = a.pricing?.output ?? undefined;
-        vb = b.pricing?.output ?? undefined;
-      } else if (sort === "context_window") {
-        va = a.context_window ?? undefined;
-        vb = b.context_window ?? undefined;
-      } else if (sort === "name") {
-        va = a.name.toLowerCase();
-        vb = b.name.toLowerCase();
-      }
-      if (va == null && vb == null) return 0;
-      if (va == null) return 1;
-      if (vb == null) return -1;
-      return va < vb ? -order : va > vb ? order : 0;
-    });
+    const order = c.req.query("order") === "desc" ? -1 : 1;
+    sortModels(models, sort, order as 1 | -1);
   }
 
   const { limit, offset } = paginate(c);
@@ -333,15 +298,7 @@ app.get("/models/recommend", (c) => {
     );
   }
 
-  // Sort: prefer models with pricing info, then by price (cheapest first)
-  models.sort((a, b) => {
-    const pa = a.pricing?.input;
-    const pb = b.pricing?.input;
-    if (pa == null && pb == null) return 0;
-    if (pa == null) return 1;
-    if (pb == null) return -1;
-    return pa - pb;
-  });
+  sortModels(models, "price_input");
 
   const { limit, offset } = paginate(c);
 
@@ -357,25 +314,9 @@ app.get("/models/recommend", (c) => {
 // ── GET /v1/models/types ──
 
 app.get("/models/types", (c) => {
-  const typeMap = new Map<string, { count: number; providers: Set<string> }>();
-
-  for (const m of allModels) {
-    const t = m.model_type ?? "unknown";
-    const entry = typeMap.get(t) ?? { count: 0, providers: new Set() };
-    entry.count++;
-    entry.providers.add(m.provider);
-    typeMap.set(t, entry);
-  }
-
-  const types = [...typeMap.entries()]
-    .map(([name, info]) => ({
-      name,
-      model_count: info.count,
-      provider_count: info.providers.size,
-    }))
-    .sort((a, b) => b.model_count - a.model_count);
-
-  return c.json(ok(types));
+  return c.json(
+    ok(aggregateByKey(allModels, (m) => m.model_type ?? "unknown")),
+  );
 });
 
 // ── GET /v1/models/:provider/:id ──
@@ -432,7 +373,6 @@ app.get("/pricing/compare", (c) => {
   let models: Model[];
 
   if (ids && ids.length > 0) {
-    // Compare specific models
     models = ids
       .map((id) => {
         const [provider, ...rest] = id.split("/");
@@ -440,87 +380,29 @@ app.get("/pricing/compare", (c) => {
       })
       .filter((m): m is Model => m != null);
   } else {
-    // Filter all models with pricing data
     models = allModels.filter(
       (m) => m.pricing?.input != null || m.pricing?.output != null,
     );
   }
 
-  // Optional price range filters
-  const minInput = Number(c.req.query("min_price_input")) || 0;
-  const maxInput = Number(c.req.query("max_price_input")) || 0;
-  if (minInput > 0) {
-    models = models.filter((m) => (m.pricing?.input ?? 0) >= minInput);
-  }
-  if (maxInput > 0) {
-    models = models.filter(
-      (m) => m.pricing?.input != null && m.pricing.input <= maxInput,
-    );
-  }
-
-  // Sort by input price ascending by default
-  const sort = c.req.query("sort") ?? "price_input";
-  const order = c.req.query("order") === "desc" ? -1 : 1;
-  models.sort((a, b) => {
-    const va =
-      sort === "price_output"
-        ? (a.pricing?.output ?? undefined)
-        : (a.pricing?.input ?? undefined);
-    const vb =
-      sort === "price_output"
-        ? (b.pricing?.output ?? undefined)
-        : (b.pricing?.input ?? undefined);
-    if (va == null && vb == null) return 0;
-    if (va == null) return 1;
-    if (vb == null) return -1;
-    return va < vb ? -order : va > vb ? order : 0;
+  const { limit, offset } = paginate(c);
+  const result = comparePricing(models, {
+    min_price_input: Number(c.req.query("min_price_input")) || undefined,
+    max_price_input: Number(c.req.query("max_price_input")) || undefined,
+    sort:
+      (c.req.query("sort") as "price_input" | "price_output") ?? "price_input",
+    order: (c.req.query("order") === "desc" ? -1 : 1) as 1 | -1,
+    limit,
+    offset,
   });
 
-  const { limit, offset } = paginate(c);
-
-  const result = models.slice(offset, offset + limit).map((m) => ({
-    id: `${m.provider}/${m.id}`,
-    name: m.name,
-    provider: m.provider,
-    model_type: m.model_type,
-    pricing: m.pricing,
-    context_window: m.context_window,
-  }));
-
-  return c.json(
-    ok(result, {
-      total: models.length,
-      limit,
-      offset,
-    }),
-  );
+  return c.json(ok(result.items, { total: result.total, limit, offset }));
 });
 
 // ── GET /v1/capabilities ──
 
 app.get("/capabilities", (c) => {
-  const capMap = new Map<string, { count: number; providers: Set<string> }>();
-
-  for (const m of allModels) {
-    if (!m.capabilities) continue;
-    for (const [key, val] of Object.entries(m.capabilities)) {
-      if (!val) continue;
-      const entry = capMap.get(key) ?? { count: 0, providers: new Set() };
-      entry.count++;
-      entry.providers.add(m.provider);
-      capMap.set(key, entry);
-    }
-  }
-
-  const capabilities = [...capMap.entries()]
-    .map(([name, info]) => ({
-      name,
-      model_count: info.count,
-      provider_count: info.providers.size,
-    }))
-    .sort((a, b) => b.model_count - a.model_count);
-
-  return c.json(ok(capabilities));
+  return c.json(ok(aggregateCapabilities(allModels)));
 });
 
 // ── GET /v1/modalities ──
@@ -554,100 +436,36 @@ app.get("/modalities", (c) => {
 // ── GET /v1/tools ──
 
 app.get("/tools", (c) => {
-  const toolMap = new Map<string, { count: number; providers: Set<string> }>();
-
-  for (const m of allModels) {
-    if (!m.tools) continue;
-    for (const tool of m.tools) {
-      const entry = toolMap.get(tool) ?? { count: 0, providers: new Set() };
-      entry.count++;
-      entry.providers.add(m.provider);
-      toolMap.set(tool, entry);
-    }
-  }
-
-  const tools = [...toolMap.entries()]
-    .map(([name, info]) => ({
-      name,
-      model_count: info.count,
-      provider_count: info.providers.size,
-    }))
-    .sort((a, b) => b.model_count - a.model_count);
-
-  return c.json(ok(tools));
+  return c.json(
+    ok(aggregateByKey(allModels, (m) => m.tools as string[] | undefined)),
+  );
 });
 
 // ── GET /v1/search ──
 
 app.get("/search", (c) => {
-  const q = c.req.query("q")?.toLowerCase();
+  const q = c.req.query("q");
   if (!q || q.length < 2)
     return c.json(err("Query must be at least 2 characters", 400), 400);
 
   const limit = Math.min(Number(c.req.query("limit")) || 20, 50);
+  const result = searchAll(q, limit);
 
-  const matchedProviders = providers
-    .filter(
-      (p) => p.name.toLowerCase().includes(q) || p.id.toLowerCase().includes(q),
-    )
-    .slice(0, 5)
-    .map((p) => ({
-      type: "provider",
-      id: p.id,
-      name: p.name,
-      url: `/${p.id}`,
-    }));
-
-  const matchedModels = allModels
-    .filter(
-      (m) =>
-        m.id.toLowerCase().includes(q) ||
-        m.name.toLowerCase().includes(q) ||
-        m.family?.toLowerCase().includes(q),
-    )
-    .slice(0, limit)
-    .map((m) => ({
-      type: "model",
-      id: `${m.provider}/${m.id}`,
-      name: m.name,
-      provider: m.provider,
-      url: `/${m.provider}/${m.id}`,
-    }));
-
-  return c.json(ok({ providers: matchedProviders, models: matchedModels }));
+  return c.json(
+    ok({
+      providers: result.providers.map((p) => ({ ...p, url: `/${p.id}` })),
+      models: result.models.map((m) => ({
+        ...m,
+        url: `/${m.provider}/${m.id.split("/").slice(1).join("/")}`,
+      })),
+    }),
+  );
 });
 
 // ── GET /v1/families ──
 
 app.get("/families", (c) => {
-  const familyMap = new Map<
-    string,
-    { count: number; providers: Set<string>; creators: Set<string> }
-  >();
-
-  for (const m of allModels) {
-    if (!m.family) continue;
-    const entry = familyMap.get(m.family) ?? {
-      count: 0,
-      providers: new Set(),
-      creators: new Set(),
-    };
-    entry.count++;
-    entry.providers.add(m.provider);
-    if (m.created_by) entry.creators.add(m.created_by);
-    familyMap.set(m.family, entry);
-  }
-
-  const families = [...familyMap.entries()]
-    .map(([name, info]) => ({
-      name,
-      model_count: info.count,
-      providers: [...info.providers],
-      creators: [...info.creators],
-    }))
-    .sort((a, b) => b.model_count - a.model_count);
-
-  return c.json(ok(families));
+  return c.json(ok(aggregateFamilies(allModels)));
 });
 
 // ── Export ──

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -4,6 +4,15 @@ import type { Model } from "@modelpedia/data";
 import { allModels, getModel, getProvider, providers } from "@modelpedia/data";
 import type { Context } from "hono";
 import { z } from "zod/v4";
+import {
+  aggregateCapabilities,
+  aggregateFamilies,
+  comparePricing,
+  filterModels,
+  type SortField,
+  searchAll,
+  sortModels,
+} from "./query";
 
 function createMcpServer() {
   const server = new McpServer({
@@ -114,60 +123,19 @@ function createMcpServer() {
       offset: z.optional(z.number().describe("Offset for pagination")),
     },
     async (params) => {
-      let models: Model[] = [...allModels];
-
-      if (params.provider)
-        models = models.filter((m) => m.provider === params.provider);
-      if (params.family)
-        models = models.filter((m) => m.family === params.family);
-      if (params.creator)
-        models = models.filter((m) => m.created_by === params.creator);
-      if (params.status)
-        models = models.filter((m) => m.status === params.status);
-      if (params.model_type)
-        models = models.filter((m) => m.model_type === params.model_type);
-      if (params.capability) {
-        models = models.filter(
-          (m) =>
-            m.capabilities?.[params.capability as keyof typeof m.capabilities],
-        );
-      }
-
-      if (params.q) {
-        const q = params.q.toLowerCase();
-        models = models.filter(
-          (m) =>
-            m.id.toLowerCase().includes(q) ||
-            m.name.toLowerCase().includes(q) ||
-            m.description?.toLowerCase().includes(q) ||
-            m.family?.toLowerCase().includes(q) ||
-            m.created_by?.toLowerCase().includes(q),
-        );
-      }
+      const models = filterModels([...allModels], {
+        provider: params.provider,
+        family: params.family,
+        creator: params.creator,
+        status: params.status,
+        capability: params.capability,
+        model_type: params.model_type,
+        q: params.q,
+      });
 
       if (params.sort) {
         const order = params.order === "desc" ? -1 : 1;
-        models.sort((a, b) => {
-          let va: number | string | undefined;
-          let vb: number | string | undefined;
-          if (params.sort === "price_input") {
-            va = a.pricing?.input ?? undefined;
-            vb = b.pricing?.input ?? undefined;
-          } else if (params.sort === "price_output") {
-            va = a.pricing?.output ?? undefined;
-            vb = b.pricing?.output ?? undefined;
-          } else if (params.sort === "context_window") {
-            va = a.context_window ?? undefined;
-            vb = b.context_window ?? undefined;
-          } else if (params.sort === "name") {
-            va = a.name.toLowerCase();
-            vb = b.name.toLowerCase();
-          }
-          if (va == null && vb == null) return 0;
-          if (va == null) return 1;
-          if (vb == null) return -1;
-          return va < vb ? -order : va > vb ? order : 0;
-        });
+        sortModels(models, params.sort as SortField, order as 1 | -1);
       }
 
       const limit = Math.min(params.limit ?? 20, 100);
@@ -337,15 +305,7 @@ function createMcpServer() {
         );
       }
 
-      // Sort by price ascending
-      models.sort((a, b) => {
-        const pa = a.pricing?.input;
-        const pb = b.pricing?.input;
-        if (pa == null && pb == null) return 0;
-        if (pa == null) return 1;
-        if (pb == null) return -1;
-        return pa - pb;
-      });
+      sortModels(models, "price_input");
 
       const limit = Math.min(params.limit ?? 10, 50);
 
@@ -404,51 +364,20 @@ function createMcpServer() {
         );
       }
 
-      if (params.min_price_input) {
-        models = models.filter(
-          (m) => (m.pricing?.input ?? 0) >= params.min_price_input!,
-        );
-      }
-      if (params.max_price_input) {
-        models = models.filter(
-          (m) =>
-            m.pricing?.input != null &&
-            m.pricing.input <= params.max_price_input!,
-        );
-      }
-
-      const sort = params.sort ?? "price_input";
-      const order = params.order === "desc" ? -1 : 1;
-      models.sort((a, b) => {
-        const va =
-          sort === "price_output"
-            ? (a.pricing?.output ?? undefined)
-            : (a.pricing?.input ?? undefined);
-        const vb =
-          sort === "price_output"
-            ? (b.pricing?.output ?? undefined)
-            : (b.pricing?.input ?? undefined);
-        if (va == null && vb == null) return 0;
-        if (va == null) return 1;
-        if (vb == null) return -1;
-        return va < vb ? -order : va > vb ? order : 0;
-      });
-
       const limit = Math.min(params.limit ?? 20, 100);
-      const result = models.slice(0, limit).map((m) => ({
-        id: `${m.provider}/${m.id}`,
-        name: m.name,
-        provider: m.provider,
-        model_type: m.model_type,
-        pricing: m.pricing,
-        context_window: m.context_window,
-      }));
+      const result = comparePricing(models, {
+        min_price_input: params.min_price_input,
+        max_price_input: params.max_price_input,
+        sort: params.sort,
+        order: (params.order === "desc" ? -1 : 1) as 1 | -1,
+        limit,
+      });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ models: result, total: models.length }),
+            text: JSON.stringify({ models: result.items, total: result.total }),
           },
         ],
       };
@@ -474,43 +403,11 @@ function createMcpServer() {
         };
       }
 
-      const query = q.toLowerCase();
       const limit = Math.min(maxResults ?? 20, 50);
-
-      const matchedProviders = providers
-        .filter(
-          (p) =>
-            p.name.toLowerCase().includes(query) ||
-            p.id.toLowerCase().includes(query),
-        )
-        .slice(0, 5)
-        .map((p) => ({ type: "provider", id: p.id, name: p.name }));
-
-      const matchedModels = allModels
-        .filter(
-          (m) =>
-            m.id.toLowerCase().includes(query) ||
-            m.name.toLowerCase().includes(query) ||
-            m.family?.toLowerCase().includes(query),
-        )
-        .slice(0, limit)
-        .map((m) => ({
-          type: "model",
-          id: `${m.provider}/${m.id}`,
-          name: m.name,
-          provider: m.provider,
-        }));
+      const result = searchAll(q, limit);
 
       return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              providers: matchedProviders,
-              models: matchedModels,
-            }),
-          },
-        ],
+        content: [{ type: "text", text: JSON.stringify(result) }],
       };
     },
   );
@@ -522,32 +419,13 @@ function createMcpServer() {
     "List all available model capabilities with counts",
     {},
     async () => {
-      const capMap = new Map<
-        string,
-        { count: number; providers: Set<string> }
-      >();
-
-      for (const m of allModels) {
-        if (!m.capabilities) continue;
-        for (const [key, val] of Object.entries(m.capabilities)) {
-          if (!val) continue;
-          const entry = capMap.get(key) ?? { count: 0, providers: new Set() };
-          entry.count++;
-          entry.providers.add(m.provider);
-          capMap.set(key, entry);
-        }
-      }
-
-      const capabilities = [...capMap.entries()]
-        .map(([name, info]) => ({
-          name,
-          model_count: info.count,
-          provider_count: info.providers.size,
-        }))
-        .sort((a, b) => b.model_count - a.model_count);
-
       return {
-        content: [{ type: "text", text: JSON.stringify(capabilities) }],
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(aggregateCapabilities(allModels)),
+          },
+        ],
       };
     },
   );
@@ -559,35 +437,10 @@ function createMcpServer() {
     "List all model families with model counts and associated providers",
     {},
     async () => {
-      const familyMap = new Map<
-        string,
-        { count: number; providers: Set<string>; creators: Set<string> }
-      >();
-
-      for (const m of allModels) {
-        if (!m.family) continue;
-        const entry = familyMap.get(m.family) ?? {
-          count: 0,
-          providers: new Set(),
-          creators: new Set(),
-        };
-        entry.count++;
-        entry.providers.add(m.provider);
-        if (m.created_by) entry.creators.add(m.created_by);
-        familyMap.set(m.family, entry);
-      }
-
-      const families = [...familyMap.entries()]
-        .map(([name, info]) => ({
-          name,
-          model_count: info.count,
-          providers: [...info.providers],
-          creators: [...info.creators],
-        }))
-        .sort((a, b) => b.model_count - a.model_count);
-
       return {
-        content: [{ type: "text", text: JSON.stringify(families) }],
+        content: [
+          { type: "text", text: JSON.stringify(aggregateFamilies(allModels)) },
+        ],
       };
     },
   );
@@ -595,9 +448,10 @@ function createMcpServer() {
   return server;
 }
 
+const mcpServer = createMcpServer();
+
 export async function handleMcp(c: Context) {
-  const server = createMcpServer();
   const transport = new StreamableHTTPTransport();
-  await server.connect(transport);
+  await mcpServer.connect(transport);
   return transport.handleRequest(c);
 }

--- a/apps/api/src/query.ts
+++ b/apps/api/src/query.ts
@@ -1,0 +1,232 @@
+import type { Model } from "@modelpedia/data";
+import { allModels, providers } from "@modelpedia/data";
+
+// ── Filter ──
+
+export interface FilterParams {
+  provider?: string;
+  family?: string;
+  creator?: string;
+  status?: string;
+  capability?: string;
+  model_type?: string;
+  q?: string;
+}
+
+export function filterModels(models: Model[], params: FilterParams): Model[] {
+  let result = models;
+
+  if (params.provider)
+    result = result.filter((m) => m.provider === params.provider);
+  if (params.family) result = result.filter((m) => m.family === params.family);
+  if (params.creator)
+    result = result.filter((m) => m.created_by === params.creator);
+  if (params.status) result = result.filter((m) => m.status === params.status);
+  if (params.model_type)
+    result = result.filter((m) => m.model_type === params.model_type);
+  if (params.capability) {
+    result = result.filter(
+      (m) => m.capabilities?.[params.capability as keyof typeof m.capabilities],
+    );
+  }
+  if (params.q) {
+    const q = params.q.toLowerCase();
+    result = result.filter(
+      (m) =>
+        m.id.toLowerCase().includes(q) ||
+        m.name.toLowerCase().includes(q) ||
+        m.description?.toLowerCase().includes(q) ||
+        m.family?.toLowerCase().includes(q) ||
+        m.created_by?.toLowerCase().includes(q),
+    );
+  }
+
+  return result;
+}
+
+// ── Sort ──
+
+export type SortField =
+  | "price_input"
+  | "price_output"
+  | "context_window"
+  | "name";
+
+export function sortModels(
+  models: Model[],
+  sort: SortField,
+  order: 1 | -1 = 1,
+): Model[] {
+  return models.sort((a, b) => {
+    let va: number | string | undefined;
+    let vb: number | string | undefined;
+    if (sort === "price_input") {
+      va = a.pricing?.input ?? undefined;
+      vb = b.pricing?.input ?? undefined;
+    } else if (sort === "price_output") {
+      va = a.pricing?.output ?? undefined;
+      vb = b.pricing?.output ?? undefined;
+    } else if (sort === "context_window") {
+      va = a.context_window ?? undefined;
+      vb = b.context_window ?? undefined;
+    } else if (sort === "name") {
+      va = a.name.toLowerCase();
+      vb = b.name.toLowerCase();
+    }
+    if (va == null && vb == null) return 0;
+    if (va == null) return 1;
+    if (vb == null) return -1;
+    return va < vb ? -order : va > vb ? order : 0;
+  });
+}
+
+// ── Aggregation ──
+
+export interface AggEntry {
+  name: string;
+  model_count: number;
+  provider_count: number;
+}
+
+export function aggregateByKey(
+  models: Model[],
+  keyFn: (m: Model) => string | string[] | undefined,
+): AggEntry[] {
+  const map = new Map<string, { count: number; providers: Set<string> }>();
+
+  for (const m of models) {
+    const keys = keyFn(m);
+    if (keys == null) continue;
+    const arr = Array.isArray(keys) ? keys : [keys];
+    for (const key of arr) {
+      if (!key) continue;
+      const entry = map.get(key) ?? { count: 0, providers: new Set() };
+      entry.count++;
+      entry.providers.add(m.provider);
+      map.set(key, entry);
+    }
+  }
+
+  return [...map.entries()]
+    .map(([name, info]) => ({
+      name,
+      model_count: info.count,
+      provider_count: info.providers.size,
+    }))
+    .sort((a, b) => b.model_count - a.model_count);
+}
+
+export function aggregateCapabilities(models: Model[]): AggEntry[] {
+  return aggregateByKey(models, (m) => {
+    if (!m.capabilities) return undefined;
+    return Object.entries(m.capabilities)
+      .filter(([, v]) => v)
+      .map(([k]) => k);
+  });
+}
+
+export function aggregateFamilies(models: Model[]) {
+  const map = new Map<
+    string,
+    { count: number; providers: Set<string>; creators: Set<string> }
+  >();
+
+  for (const m of models) {
+    if (!m.family) continue;
+    const entry = map.get(m.family) ?? {
+      count: 0,
+      providers: new Set(),
+      creators: new Set(),
+    };
+    entry.count++;
+    entry.providers.add(m.provider);
+    if (m.created_by) entry.creators.add(m.created_by);
+    map.set(m.family, entry);
+  }
+
+  return [...map.entries()]
+    .map(([name, info]) => ({
+      name,
+      model_count: info.count,
+      providers: [...info.providers],
+      creators: [...info.creators],
+    }))
+    .sort((a, b) => b.model_count - a.model_count);
+}
+
+// ── Search ──
+
+export function searchAll(q: string, limit = 20) {
+  const query = q.toLowerCase();
+
+  const matchedProviders = providers
+    .filter(
+      (p) =>
+        p.name.toLowerCase().includes(query) ||
+        p.id.toLowerCase().includes(query),
+    )
+    .slice(0, 5)
+    .map((p) => ({ type: "provider" as const, id: p.id, name: p.name }));
+
+  const matchedModels = allModels
+    .filter(
+      (m) =>
+        m.id.toLowerCase().includes(query) ||
+        m.name.toLowerCase().includes(query) ||
+        m.family?.toLowerCase().includes(query),
+    )
+    .slice(0, limit)
+    .map((m) => ({
+      type: "model" as const,
+      id: `${m.provider}/${m.id}`,
+      name: m.name,
+      provider: m.provider,
+    }));
+
+  return { providers: matchedProviders, models: matchedModels };
+}
+
+// ── Pricing comparison ──
+
+export function comparePricing(
+  models: Model[],
+  params: {
+    min_price_input?: number;
+    max_price_input?: number;
+    sort?: "price_input" | "price_output";
+    order?: 1 | -1;
+    limit?: number;
+    offset?: number;
+  },
+) {
+  let filtered = models;
+
+  if (params.min_price_input && params.min_price_input > 0) {
+    filtered = filtered.filter(
+      (m) => (m.pricing?.input ?? 0) >= params.min_price_input!,
+    );
+  }
+  if (params.max_price_input && params.max_price_input > 0) {
+    filtered = filtered.filter(
+      (m) =>
+        m.pricing?.input != null && m.pricing.input <= params.max_price_input!,
+    );
+  }
+
+  sortModels(filtered, params.sort ?? "price_input", params.order ?? 1);
+
+  const limit = params.limit ?? 20;
+  const offset = params.offset ?? 0;
+
+  return {
+    items: filtered.slice(offset, offset + limit).map((m) => ({
+      id: `${m.provider}/${m.id}`,
+      name: m.name,
+      provider: m.provider,
+      model_type: m.model_type,
+      pricing: m.pricing,
+      context_window: m.context_window,
+    })),
+    total: filtered.length,
+  };
+}

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { PROVIDER_TYPE_TIER } from "@/lib/constants";
+import { allModels, getProvider } from "@/lib/data";
+import { multiSearch } from "@/lib/search";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.trim();
+
+  if (!q || q.length < 2) {
+    return NextResponse.json({ models: [] });
+  }
+
+  const items = allModels
+    .filter((m) => m.status !== "deprecated")
+    .map((m) => {
+      const p = getProvider(m.provider);
+      return {
+        type: "model" as const,
+        id: `${m.provider}/${m.id}`,
+        name: m.name,
+        href: `/${m.provider}/${m.id}`,
+        sub: p?.name ?? m.provider,
+        icon: p?.icon,
+        providerType: p?.type ?? "direct",
+      };
+    });
+
+  const results = multiSearch(items, q, {
+    target: (m) => `${m.name} ${m.sub ?? ""} ${m.id}`,
+    bonus: (m) => {
+      let b = 0;
+      if (m.name.toLowerCase() === q.toLowerCase()) b += 30;
+      b += PROVIDER_TYPE_TIER[m.providerType] ?? 0;
+      return b;
+    },
+    limit: 20,
+  });
+
+  return NextResponse.json({
+    models: results.map(({ providerType, ...rest }) => rest),
+  });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/shared/footer";
 import { FormatToggle } from "@/components/shared/format-toggle";
 import { Header } from "@/components/shared/header";
 import { cn } from "@/lib/cn";
-import { allModels, getProvider, providers } from "@/lib/data";
+import { providers } from "@/lib/data";
 import { geistMono, geistSans } from "@/styles/font";
 import "@/styles/globals.css";
 import { Provider } from "./provider";
@@ -81,19 +81,6 @@ export default async function RootLayout({
       sub: `${p.models.length} models`,
       icon: p.icon,
     })),
-    models: allModels
-      .filter((m) => m.status !== "deprecated")
-      .map((m) => {
-        const p = getProvider(m.provider);
-        return {
-          type: "model" as const,
-          id: `${m.provider}/${m.id}`,
-          name: m.name,
-          href: `/${m.provider}/${m.id}`,
-          sub: p?.name ?? m.provider,
-          icon: p?.icon,
-        };
-      }),
   };
 
   return (

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -3,21 +3,41 @@ import { providers } from "@/lib/data";
 
 const BASE = "https://modelpedia.dev";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const staticPages: MetadataRoute.Sitemap = [
-    { url: BASE, changeFrequency: "daily", priority: 1.0 },
-    { url: `${BASE}/models`, changeFrequency: "daily", priority: 0.9 },
-    { url: `${BASE}/providers`, changeFrequency: "weekly", priority: 0.8 },
-    { url: `${BASE}/compare`, changeFrequency: "weekly", priority: 0.7 },
-    { url: `${BASE}/changes`, changeFrequency: "daily", priority: 0.7 },
-    { url: `${BASE}/docs/api`, changeFrequency: "monthly", priority: 0.6 },
-  ];
+export async function generateSitemaps() {
+  return [{ id: "main" }, ...providers.map((p) => ({ id: p.id }))];
+}
 
-  const providerPages: MetadataRoute.Sitemap = providers.map((p) => ({
-    url: `${BASE}/${p.id}`,
-    changeFrequency: "weekly",
-    priority: p.type === "direct" ? 0.8 : 0.6,
-  }));
+export default async function sitemap({
+  id,
+}: {
+  id: string;
+}): Promise<MetadataRoute.Sitemap> {
+  if (id === "main") {
+    return [
+      { url: BASE, changeFrequency: "daily", priority: 1.0 },
+      { url: `${BASE}/models`, changeFrequency: "daily", priority: 0.9 },
+      { url: `${BASE}/providers`, changeFrequency: "weekly", priority: 0.8 },
+      { url: `${BASE}/compare`, changeFrequency: "weekly", priority: 0.7 },
+      { url: `${BASE}/changes`, changeFrequency: "daily", priority: 0.7 },
+      { url: `${BASE}/docs/api`, changeFrequency: "monthly", priority: 0.6 },
+      ...providers.map((p) => ({
+        url: `${BASE}/${p.id}`,
+        changeFrequency: "weekly" as const,
+        priority: p.type === "direct" ? 0.8 : 0.6,
+      })),
+    ];
+  }
 
-  return [...staticPages, ...providerPages];
+  const provider = providers.find((p) => p.id === id);
+  if (!provider) return [];
+
+  const priority = provider.type === "direct" ? 0.7 : 0.5;
+
+  return provider.models
+    .filter((m) => m.status !== "deprecated" && !m.alias)
+    .map((m) => ({
+      url: `${BASE}/${provider.id}/${m.id}`,
+      changeFrequency: "weekly" as const,
+      priority,
+    }));
 }

--- a/apps/web/components/shared/command-palette.tsx
+++ b/apps/web/components/shared/command-palette.tsx
@@ -12,8 +12,6 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { cn } from "@/lib/cn";
-import { PROVIDER_TYPE_TIER } from "@/lib/constants";
-import { getProvider } from "@/lib/data";
 import { multiSearch } from "@/lib/search";
 
 interface SearchItem {
@@ -40,17 +38,18 @@ function ItemIcon({ html, size }: { html: string; size: string }) {
 export function CommandPalette({
   pages,
   providers,
-  models,
 }: {
   pages: SearchItem[];
   providers: SearchItem[];
-  models: SearchItem[];
 }) {
   const [mounted, setMounted] = useState(false);
   const [visible, setVisible] = useState(false);
   const [query, setQuery] = useState("");
+  const [modelResults, setModelResults] = useState<SearchItem[]>([]);
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const closingRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
 
   const open = useCallback(() => {
     if (closingRef.current) return;
@@ -67,6 +66,7 @@ export function CommandPalette({
     setTimeout(() => {
       setMounted(false);
       setQuery("");
+      setModelResults([]);
       closingRef.current = false;
     }, 200);
   }, []);
@@ -103,6 +103,35 @@ export function CommandPalette({
     return () => document.removeEventListener("keydown", down);
   }, [mounted, close, open]);
 
+  // Fetch model results from API when query changes
+  useEffect(() => {
+    if (query.length < 2) {
+      setModelResults([]);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setModelResults(data.models ?? []);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [query]);
+
   const filteredPages = useMemo(
     () => (query ? multiSearch(pages, query, { target: (p) => p.name }) : []),
     [query, pages],
@@ -114,26 +143,6 @@ export function CommandPalette({
     [query, providers],
   );
 
-  const filteredModels = useMemo(
-    () =>
-      query.length < 2
-        ? []
-        : multiSearch(models, query, {
-            target: (m) => `${m.name} ${m.sub ?? ""} ${m.id}`,
-            bonus: (m) => {
-              let b = 0;
-              if (m.name.toLowerCase() === query.toLowerCase()) b += 30;
-              const provider = m.href.split("/")[1];
-              b +=
-                PROVIDER_TYPE_TIER[getProvider(provider)?.type ?? "direct"] ??
-                0;
-              return b;
-            },
-            limit: 20,
-          }),
-    [query, models],
-  );
-
   function select(href: string) {
     close();
     setTimeout(() => router.push(href), 200);
@@ -142,7 +151,7 @@ export function CommandPalette({
   const hasResults =
     filteredPages.length > 0 ||
     filteredProviders.length > 0 ||
-    filteredModels.length > 0;
+    modelResults.length > 0;
 
   return (
     <>
@@ -180,7 +189,7 @@ export function CommandPalette({
                 autoFocus
               />
               <CommandList>
-                {query.length > 0 && !hasResults && (
+                {query.length > 0 && !hasResults && !loading && (
                   <CommandEmpty>No results found.</CommandEmpty>
                 )}
 
@@ -245,9 +254,9 @@ export function CommandPalette({
                   </CommandGroup>
                 )}
 
-                {filteredModels.length > 0 && (
+                {modelResults.length > 0 && (
                   <CommandGroup heading="Models">
-                    {filteredModels.map((item) => (
+                    {modelResults.map((item) => (
                       <CommandItem
                         key={item.id}
                         value={item.id}

--- a/apps/web/components/shared/header.tsx
+++ b/apps/web/components/shared/header.tsx
@@ -28,14 +28,6 @@ interface HeaderProps {
       sub: string;
       icon?: string;
     }[];
-    models: {
-      type: "model";
-      id: string;
-      name: string;
-      href: string;
-      sub: string;
-      icon?: string;
-    }[];
   };
 }
 
@@ -88,7 +80,6 @@ export function Header({ commandPaletteData }: HeaderProps) {
             href: link.href,
           }))}
           providers={commandPaletteData.providers}
-          models={commandPaletteData.models}
         />
       </div>
     </nav>

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- **Extract shared query layer** (`query.ts`): Deduplicate filtering, sorting, search, and aggregation logic between REST API (`index.ts`) and MCP server (`mcp.ts`). MCP server is now a module-level singleton instead of recreated per request.
- **Lazy-load CommandPalette**: Remove 4000+ model entries from the RSC layout payload. Models are now fetched on demand from `/api/search` when the user types >= 2 characters, with AbortController debouncing. Providers (32 entries) remain inline.
- **Split sitemap by provider**: Use `generateSitemaps()` to produce a sitemap index with per-provider sub-sitemaps (33 files). Adds all non-deprecated, non-snapshot model detail pages for SEO.

## Test plan

- [ ] Verify full monorepo build passes (`pnpm build`)
- [ ] Test CommandPalette search works (open with Cmd+K, type model name)
- [ ] Verify `/sitemap/main.xml` and `/sitemap/openai.xml` render correctly
- [ ] Verify REST API endpoints return same results as before
- [ ] Verify MCP tools work via `https://api.modelpedia.dev/mcp`