### PR TITLE
fix(data): only update last_updated when model data actually changes

### DIFF
--- a/packages/data/scripts/shared.ts
+++ b/packages/data/scripts/shared.ts
@@ -587,7 +587,6 @@ export function upsertModel(provider: string, entry: ModelEntry): boolean {
   data.created_by =
     entry.created_by ?? (existing?.created_by as string) ?? provider;
   data.source = "official";
-  data.last_updated = today();
 
   const scalars = [
     "family",
@@ -784,6 +783,9 @@ export function upsertModel(provider: string, entry: ModelEntry): boolean {
       `  update ${provider}/models/${modelId}.json [${Object.keys(changedFields).join(", ")}]`,
     );
   }
+
+  // Only update last_updated when there are real data changes (or new model)
+  data.last_updated = today();
 
   writeModelJson(provider, modelId, data);
   return true;


### PR DESCRIPTION
## Summary

- Move `last_updated = today()` from unconditional assignment (before change detection) to after the diff check confirms real data changes exist
- For existing models with no actual changes, `upsertModel` returns early without writing, preserving the original `last_updated` value
- Eliminates noisy auto-update PRs where 60+ model files show only a `last_updated` date bump with no real data changes (e.g. PR #22 had 66 out of 77 files with only timestamp diffs)

## Test plan

- [ ] Run a fetch script (e.g. `bun run fetch:cohere`) and verify models with no data changes are skipped (logged as `skip <id> (no changes)`) and their JSON files remain untouched
- [ ] Verify models with real data changes still get `last_updated` set to today's date
- [ ] Verify newly created models (no existing file) get `last_updated` set correctly
- [ ] Confirm the next automated `fetch-models` workflow PR only includes files with actual data changes