### PR TITLE
fix(data): prevent false updates from multi-pass fetchers

### DIFF
--- a/packages/data/scripts/shared.ts
+++ b/packages/data/scripts/shared.ts
@@ -555,6 +555,62 @@ function protectUserEdits(
   return newGenerated;
 }
 
+// Cache the original on-disk state per model (before any writes in this run).
+// Used to detect when multiple passes produce the same final result as the original.
+const _originalOnDisk = new Map<
+  string,
+  { data: Record<string, unknown>; raw: string }
+>();
+
+function getOriginal(
+  provider: string,
+  modelId: string,
+): Record<string, unknown> | null {
+  const key = `${provider}/${modelId}`;
+  if (_originalOnDisk.has(key)) return _originalOnDisk.get(key)!.data;
+  const filePath = path.join(
+    PROVIDERS_DIR,
+    provider,
+    "models",
+    `${modelId}.json`,
+  );
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const data = JSON.parse(raw) as Record<string, unknown>;
+  _originalOnDisk.set(key, { data: JSON.parse(JSON.stringify(data)), raw });
+  return data;
+}
+
+function restoreOriginal(provider: string, modelId: string): void {
+  const key = `${provider}/${modelId}`;
+  const cached = _originalOnDisk.get(key);
+  if (!cached) return;
+  const filePath = path.join(
+    PROVIDERS_DIR,
+    provider,
+    "models",
+    `${modelId}.json`,
+  );
+  fs.writeFileSync(filePath, cached.raw, "utf-8");
+}
+
+/**
+ * Compare two model records ignoring last_updated and _generated.
+ */
+function dataEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  const skip = new Set(["last_updated", "_generated"]);
+  const keysA = Object.keys(a).filter((k) => !skip.has(k));
+  const keysB = Object.keys(b).filter((k) => !skip.has(k));
+  if (keysA.length !== keysB.length) return false;
+  for (const k of keysA) {
+    if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) return false;
+  }
+  return true;
+}
+
 /**
  * Upsert a model entry, merging with existing data.
  * Skips if existing model has source: "community".
@@ -562,6 +618,7 @@ function protectUserEdits(
 export function upsertModel(provider: string, entry: ModelEntry): boolean {
   const modelId = sanitizeModelId(entry.id);
   const existing = readModelJson(provider, modelId);
+  const original = getOriginal(provider, modelId);
 
   if (existing && existing.source === "community") {
     console.log(`  skip ${modelId} (community)`);
@@ -765,27 +822,34 @@ export function upsertModel(provider: string, entry: ModelEntry): boolean {
 
   data._generated = protectUserEdits(data, existing, generated);
 
-  // Diff: log what changed and record to changes
-  if (existing) {
-    const changedFields: Record<string, { from: unknown; to: unknown }> = {};
-    for (const [k, v] of Object.entries(data)) {
-      const oldVal = existing[k];
-      if (k === "last_updated" || k === "_generated") continue;
-      if (JSON.stringify(v) !== JSON.stringify(oldVal)) {
-        changedFields[k] = { from: oldVal, to: v };
-      }
+  // Compare against the original on-disk state (before any writes in this run).
+  // This handles cases where a model is processed multiple times (e.g. multiple
+  // snapshots overwriting the same alias file) — the final result may match the
+  // original even though intermediate writes differed.
+  if (original && dataEqual(data, original)) {
+    // Restore original file byte-for-byte if intermediate writes modified it
+    if (existing && !dataEqual(existing, original)) {
+      restoreOriginal(provider, modelId);
     }
-    if (Object.keys(changedFields).length === 0) {
-      console.log(`  skip ${modelId} (no changes)`);
-      return false;
-    }
-    console.log(
-      `  update ${provider}/models/${modelId}.json [${Object.keys(changedFields).join(", ")}]`,
-    );
+    console.log(`  skip ${modelId} (no changes)`);
+    return false;
   }
 
   // Only update last_updated when there are real data changes (or new model)
   data.last_updated = today();
+
+  if (existing) {
+    const changed: string[] = [];
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "last_updated" || k === "_generated") continue;
+      if (JSON.stringify(v) !== JSON.stringify((original ?? existing)[k])) {
+        changed.push(k);
+      }
+    }
+    console.log(
+      `  update ${provider}/models/${modelId}.json [${changed.join(", ")}]`,
+    );
+  }
 
   writeModelJson(provider, modelId, data);
   return true;


### PR DESCRIPTION
## Summary

- Cache each model's original on-disk state (parsed data + raw file content) at first access during a fetch run
- Before writing, compare the final merged result against the **original** file — not the current disk state which may reflect intermediate writes
- If the final data matches the original, restore the original file byte-for-byte (preserving formatting) and skip the update
- Fixes the root cause: fetchers process the same model multiple times (OpenAI snapshots overwriting aliases 3-4x, Cohere duplicate table rows, Mistral multiple versions) causing intermediate writes that flip data back and forth, ending at the original state but with `last_updated` bumped
- Supersedes #23 which only moved `last_updated` assignment — insufficient because the diff check compared against intermediate state, not the original

## Test plan

- [ ] Run `bun run fetch:cohere` — embed models should all show `skip (no changes)`, zero git diff in cohere/
- [ ] Run `bun run fetch:openai` — `gpt-4o.json` processed 4x but final git diff should show no `last_updated`-only changes
- [ ] Run `bun run fetch:mistral` — `mistral-small.json` processed 2x, zero git diff for unchanged models
- [ ] Run all fetchers from the workflow and verify `git diff --stat` shows only files with real data changes
- [ ] Verify new models (no existing file) still get `last_updated` set correctly