### PR TITLE
Add CoderPlan — LLM API Gateway Provider

### DIFF
--- a/packages/data/providers/coderplan/_provider.json
+++ b/packages/data/providers/coderplan/_provider.json
@@ -1,0 +1,14 @@
+{
+  "id": "coderplan",
+  "name": "CoderPlan",
+  "region": "CN",
+  "url": "https://coderplan.ai",
+  "api_url": "https://api.coderplan.ai/v1",
+  "docs_url": "https://coderplan.ai/docs",
+  "pricing_url": "https://coderplan.ai/pricing",
+  "description": "LLM API gateway for developers. OpenAI-compatible API with pay-per-use pricing, connecting Claude Code, Cursor, and other AI tools to all major models.",
+  "type": "aggregator",
+  "openai_compatible": true,
+  "free_tier": true,
+  "github_url": "https://github.com/coderplan-ai"
+}


### PR DESCRIPTION
## CoderPlan Provider

Adds CoderPlan as an LLM API provider/gateway.

**URL:** https://coderplan.ai
**API:** https://api.coderplan.ai/v1 (OpenAI-compatible)
**Type:** Aggregator (similar to OpenRouter)

### Key Features
- 🔌 OpenAI-compatible API (drop-in replacement)
- 💰 Pay-per-use, no subscription
- 🌍 Global edge nodes (US, Asia, Europe)
- 🔧 Works with Claude Code, Cursor, Continue, Cherry Studio
- 📊 Full model support: Claude, GPT-4o, Gemini, DeepSeek, etc.
- 🆓 Free tier available for new users

### Files Added
- `packages/data/providers/coderplan/_provider.json` — Provider metadata

I plan to add model files in a follow-up PR once the provider entry is established. Happy to adjust the format to match your conventions.