### PR TITLE
fix(web): repair model selection on the compare page

### DIFF
--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -25,13 +25,18 @@ export default function ComparePage() {
       };
     });
 
+  const aliases: Record<string, string> = {};
+  for (const m of allModels) {
+    if (m.alias) aliases[`${m.provider}/${m.id}`] = `${m.provider}/${m.alias}`;
+  }
+
   return (
     <>
       <PageHeader
         title="Compare Models"
         sub="Side-by-side comparison of specs, pricing, and capabilities"
       />
-      <ModelCompare models={models} />
+      <ModelCompare models={models} aliases={aliases} />
     </>
   );
 }

--- a/apps/web/components/pages/model/id/header.tsx
+++ b/apps/web/components/pages/model/id/header.tsx
@@ -65,7 +65,7 @@ export function ModelDetailHeader({
         <span className="flex-1" />
 
         <ButtonLink
-          href={`/compare?a=${encodeURIComponent(`${model.provider}/${model.id}`)}`}
+          href={`/compare?a=${encodeURIComponent(`${model.provider}/${model.alias ?? model.id}`)}`}
           variant="default"
           size="icon"
           title="Compare this model"

--- a/apps/web/components/shared/model-compare.tsx
+++ b/apps/web/components/shared/model-compare.tsx
@@ -27,7 +27,7 @@ import {
   Wrench,
   Zap,
 } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { ModelPicker } from "@/components/shared/model-picker";
 import { ProviderIcon } from "@/components/shared/provider-icon";
@@ -221,12 +221,19 @@ const CAP_KEYS: [keyof ModelCapabilities, string, LucideIcon][] = [
   ["batch", "Batch", Package],
 ];
 
-function CompareInner({ models }: { models: CompareModel[] }) {
-  const router = useRouter();
+function CompareInner({
+  models,
+  aliases,
+}: {
+  models: CompareModel[];
+  aliases: Record<string, string>;
+}) {
   const searchParams = useSearchParams();
 
-  const modelA = searchParams.get("a");
-  const modelB = searchParams.get("b");
+  const rawA = searchParams.get("a");
+  const rawB = searchParams.get("b");
+  const modelA = rawA ? (aliases[rawA] ?? rawA) : null;
+  const modelB = rawB ? (aliases[rawB] ?? rawB) : null;
 
   const a = modelA
     ? models.find((m) => `${m.provider}/${m.id}` === modelA)
@@ -240,7 +247,8 @@ function CompareInner({ models }: { models: CompareModel[] }) {
     if (aKey) params.set("a", aKey);
     if (bKey) params.set("b", bKey);
     const qs = params.toString();
-    router.push(qs ? `/compare?${qs}` : "/compare");
+    // Not router.push: Next.js 16.2.x swallows searchParams-only navigations after a hard load with search params (vercel/next.js#92187).
+    window.history.pushState(null, "", qs ? `/compare?${qs}` : "/compare");
   }
 
   return (
@@ -478,10 +486,16 @@ function CompareInner({ models }: { models: CompareModel[] }) {
   );
 }
 
-export function ModelCompare({ models }: { models: CompareModel[] }) {
+export function ModelCompare({
+  models,
+  aliases,
+}: {
+  models: CompareModel[];
+  aliases: Record<string, string>;
+}) {
   return (
     <Suspense>
-      <CompareInner models={models} />
+      <CompareInner models={models} aliases={aliases} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

two stacked bugs made compare links from model detail pages dead (e.g. `/compare?a=openai%2Fgpt-5.5-2026-04-23`): picker A stayed empty and picking model B silently did nothing.

- snapshot models (the ~210 entries carrying an `alias` field) are filtered out of the compare model list, but the detail page compare button linked them by raw `model.id`, so the `?a=` key could never resolve. the button now links `model.alias ?? model.id`, and the compare page passes an `aliases` map so old shared snapshot URLs still canonicalize client side.
- Next.js 16.2.x has a segment cache regression (vercel/next.js#92187, fixed upstream in 16.3.0-canary.31 but in no 16.2.x release): after a hard load of a URL that already has search params, every searchParams-only `router.push` is silently swallowed (no URL change, no error). `setModels` now uses native `history.pushState` shallow routing, which is the documented pattern for client-only param state and bypasses the broken code path. `router.replace` goes through the same broken path, so it was not an option.

reproduced deterministically on the live site and on a local `next build && next start`; once on Next.js >= 16.3.0 stable the pushState workaround can be revisited, the alias canonicalization stays either way.

## Type

- [ ] Model data fix (correcting wrong values)
- [ ] New model or provider
- [ ] Fetch script improvement
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Source

https://github.com/vercel/next.js/issues/92187 (upstream router regression this works around)

## Checklist

- [ ] `pnpm validate` passes (for data changes)
- [x] `pnpm lint` passes
- [ ] Data changes include a source link

## Test plan

verified on a local production build (`pnpm build && pnpm start`):

- [x] hard load `/compare?a=openai%2Fgpt-5.5-2026-04-23`: picker A shows GPT-5.5, picking model B updates the URL (self-healing `a` to the canonical id) and renders the comparison table
- [x] hard load `/compare?b=...` then picking model A works (previously the same silent no-op)
- [x] clean `/compare`: pick A, pick B, clear selection, browser back/forward all update URL and table correctly
- [x] snapshot detail page `/openai/gpt-5.5-2026-04-23` compare button now links `/compare?a=openai%2Fgpt-5.5`