### PR TITLE
fix(data): keep the canonical id when retiring a model

### DIFF
--- a/packages/data/scripts/shared.ts
+++ b/packages/data/scripts/shared.ts
@@ -189,7 +189,11 @@ function sweepDeprecated(priorCounts: Map<string, number>): void {
         continue;
       }
       upsertModel(provider, {
-        id,
+        // The filename is the sanitized id, so passing it back rewrites the
+        // canonical one: `amazon.nova-reel-v1:1` became `amazon.nova-reel-v1-1`
+        // on every model this retired. upsertModel sanitizes again to locate
+        // the file, so handing it the real id still resolves to this one.
+        id: (existing.id as string) ?? id,
         name: (existing.name as string) ?? id,
         status: "deprecated",
       } as ModelEntry);


### PR DESCRIPTION
## summary

The deprecation sweep from #89 read a model's id from its filename, which is the sanitized form, and handed that back to `upsertModel` as the model's id. Retiring a model therefore rewrote it:

```diff
-  "id": "amazon.nova-reel-v1:1",
+  "id": "amazon.nova-reel-v1-1",
-  "id": "abacusai/dracarys-llama-3.1-70b-instruct",
+  "id": "abacusai-dracarys-llama-3.1-70b-instruct",
```

The sweep's first real pass retired 799 models and **corrupted 564 ids** this way. Those strings are what callers pass to the provider's API, so the damage is user-visible rather than cosmetic.

The id now comes from the file's own `id` field. `upsertModel` sanitizes again to locate the file, so the real id still resolves to the same one.

**#93 carries the corruption and should not be merged.** Re-running the workflow on top of this rebuilds `data/auto-update` from main and produces a clean update.

## type

- [ ] Model data fix (correcting wrong values)
- [ ] New model or provider
- [x] Fetch script improvement
- [x] Bug fix
- [ ] Feature
- [ ] Other

## source

Script-only, one file. The daily workflow regenerates the data.

## checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` passes (5/5)
- [ ] `pnpm validate` passes (for data changes) (n/a, no data changes)
- [ ] Data changes include a source link (n/a, no data changes)

## reviewer should verify

- [ ] `bun run fetch:amazon` retires its delisted models with their ids intact: `luma.ray-v2:0`, `mistral.mistral-large-2407-v1:0` and `stability.sd3-5-large-v1:0` keep the colon while gaining `status: deprecated`.

## notes

- The sweep otherwise behaved as designed on its first real pass: 799 retirements against the 801 predicted in #89, matching per provider (fal 144, nvidia 113, replicate 96, openrouter 86, together 42), with no interlock refusals. That is also what confirms `PARTIAL_WRITERS` is complete, the one assumption in the sweep no test can cover.
- The baseline ratchet flagged `nvidia` and `replicate` field-coverage drops on the same run. Those are unrelated to this bug (no field was removed in the diff) and still need a look.