### PR TITLE
feat(api): drain telemetry to axiom and return structured errors

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -612,4 +612,21 @@ app.get("/export", (c) => {
 
 api.route("/v1", app);
 
+api.notFound((c) =>
+  c.json({ error: { message: "Not found", status: 404 } }, 404),
+);
+
+api.onError((err, c) => {
+  console.error({
+    msg: "api.error",
+    method: c.req.method,
+    path: c.req.path,
+    error: err instanceof Error ? err.message : String(err),
+  });
+  return c.json(
+    { error: { message: "Internal server error", status: 500 } },
+    500,
+  );
+});
+
 export default api;

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -5,8 +5,19 @@
   "compatibility_date": "2026-03-14",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "destinations": ["axiom-logs"],
+      "head_sampling_rate": 1,
+      "invocation_logs": true,
+      "persist": false,
+    },
+    "traces": {
+      "enabled": true,
+      "destinations": ["axiom-traces"],
+      "head_sampling_rate": 1,
+      "persist": false,
+    },
   },
   "ratelimits": [
     {


### PR DESCRIPTION
## problem

the worker had observability enabled but no destination, no error handler, and no notFound handler: 5xx and unmatched routes were invisible outside the Cloudflare dashboard and returned Hono's default text bodies while every real route speaks JSON.

## change

move the wrangler observability block to the nested logs/traces form with `axiom-logs` / `axiom-traces` destinations and invocation logs on, and add `api.onError` (structured console.error plus a JSON 500) and `api.notFound` (JSON 404) matching the existing `{ error: { message, status } }` shape.

## verification

`wrangler deploy --dry-run` passes with the new config. after deploy the `modelpedia-api` script name appears in the Axiom `cloudflare` dataset and route errors carry method and path.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5eFIFZ1HtxI5gCoAP7YZjMk_7h5XLz79NFx4B_-PPn7WpqdaGWEYmOcOM-k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->