### PR TITLE
ci: report pipeline telemetry to axiom

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -72,3 +72,22 @@ jobs:
           git add packages/data/changes/changes.jsonl
           git commit -m "data(changes): update"
           git push
+
+      # Each appended change record lands in Axiom trimmed to the monitorable
+      # shape: changed field names plus pricing before/after, never the long
+      # description diffs.
+      - name: Report changes to Axiom
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+        run: |
+          [ -z "$AXIOM_TOKEN" ] && { echo "AXIOM_TOKEN not set; skipping"; exit 0; }
+          git diff HEAD~1 -- packages/data/changes/changes.jsonl | grep '^+{' | sed 's/^+//' | \
+            jq -c '{msg:"model.change", _time:.ts, provider, model, action, commit, fields:((.changes // {}) | keys), pricing_from_input:(getpath(["changes","pricing","from","input"])), pricing_from_output:(getpath(["changes","pricing","from","output"])), pricing_to_input:(getpath(["changes","pricing","to","input"])), pricing_to_output:(getpath(["changes","pricing","to","output"]))} | with_entries(select(.value != null))' \
+            > /tmp/axiom-changes.ndjson || true
+          [ -s /tmp/axiom-changes.ndjson ] || { echo "no change lines to report"; exit 0; }
+          curl -sf -X POST "https://api.axiom.co/v1/datasets/modelpedia-pipeline/ingest" \
+            -H "Authorization: Bearer $AXIOM_TOKEN" \
+            -H "Content-Type: application/x-ndjson" \
+            --data-binary @/tmp/axiom-changes.ndjson > /dev/null \
+            || echo "::warning::axiom ingest failed"

--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -170,3 +170,39 @@ jobs:
               --title "data: update model data $(date +%Y-%m-%d)" \
               --body "$BODY"
           fi
+
+      # Freshness and scrape health land in Axiom so a stale data PR or a
+      # broken provider raises an alert instead of hiding in a green run.
+      # dataAgeHours comes from the GitHub API because the checkout is shallow
+      # and the branch step above rewrites local history.
+      - name: Report pipeline telemetry to Axiom
+        if: always()
+        env:
+          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          [ -z "$AXIOM_TOKEN" ] && { echo "AXIOM_TOKEN not set; skipping"; exit 0; }
+          LAST_DATA_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits?path=packages/data/providers&sha=main&per_page=1" --jq '.[0].commit.committer.date')
+          AGE_HOURS=$(( ( $(date +%s) - $(date -d "$LAST_DATA_COMMIT" +%s) ) / 3600 ))
+          FAILED_JSON="[]"
+          FAILED_COUNT=0
+          if [ -f "$GITHUB_WORKSPACE/fetch-failures.txt" ]; then
+            FAILED_JSON=$(jq -R . "$GITHUB_WORKSPACE/fetch-failures.txt" | jq -cs .)
+            FAILED_COUNT=$(wc -l < "$GITHUB_WORKSPACE/fetch-failures.txt" | tr -d ' ')
+          fi
+          {
+            jq -cn --arg runId "$GITHUB_RUN_ID" --arg status "$JOB_STATUS" \
+              --argjson failedProviders "$FAILED_JSON" --argjson failedCount "$FAILED_COUNT" \
+              --argjson dataAgeHours "$AGE_HOURS" \
+              '{msg:"pipeline.run", runId:$runId, status:$status, failedProviders:$failedProviders, failedCount:$failedCount, dataAgeHours:$dataAgeHours}'
+            for f in packages/data/providers/*/_seen.json; do
+              p=$(basename "$(dirname "$f")")
+              jq -c --arg provider "$p" '{msg:"pipeline.provider", provider:$provider, models:.count, seenDate:.date}' "$f"
+            done
+          } > /tmp/axiom-events.ndjson
+          curl -sf -X POST "https://api.axiom.co/v1/datasets/modelpedia-pipeline/ingest" \
+            -H "Authorization: Bearer $AXIOM_TOKEN" \
+            -H "Content-Type: application/x-ndjson" \
+            --data-binary @/tmp/axiom-events.ndjson > /dev/null \
+            || echo "::warning::axiom ingest failed"


### PR DESCRIPTION
## problem

the data pipeline's health signals (scrape failures, per-provider staleness, and above all the age of the last merged data commit) live only in GitHub Actions run summaries nobody subscribes to. the auto-update PR sat unmerged for 14 days with every run green and nothing alerted.

## change

two workflow steps, both no-ops until an `AXIOM_TOKEN` secret exists:

- fetch-models: after the PR step (`if: always()`), emit one `pipeline.run` event (run status, failed provider list and count, `dataAgeHours` of the last providers commit on main via the GitHub API, since the checkout is shallow and the branch step rewrites local history) plus one `pipeline.provider` event per `_seen.json` (model count, seen date) to the `modelpedia-pipeline` Axiom dataset.
- changes: emit each newly appended `changes.jsonl` record as a `model.change` event trimmed to changed field names plus pricing before/after; long description diffs never leave the repo.

axiom monitors on top of this (data stale > 48h, pipeline silent 26h, scrapers failing, pricing zeroed) are configured in axiom, not in this repo.

## verification

yaml lints clean; both jq transforms validated locally against the real `changes.jsonl` tail and `_seen.json` files (including a pricing change that has only `to` values). the ingest step degrades to a workflow warning on failure and skips silently when the secret is unset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MEBgJtCRfIBSvro6TfSmXFlU3igotrekuZXqWdy8f-2m2fat5mgz6XnHARE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->