### PR TITLE
ci: ping a liveness heartbeat after successful fetch runs

### DIFF
--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -206,3 +206,14 @@ jobs:
             -H "Content-Type: application/x-ndjson" \
             --data-binary @/tmp/axiom-events.ndjson > /dev/null \
             || echo "::warning::axiom ingest failed"
+
+      # A successful daily run pings Better Stack; a run that stops arriving
+      # (cron disabled, workflow broken, repo archived) raises an incident even
+      # when nothing is left alive to report a failure.
+      - name: Ping Better Stack heartbeat
+        if: success()
+        env:
+          HEARTBEAT_URL: ${{ secrets.BETTERSTACK_HEARTBEAT_URL }}
+        run: |
+          [ -z "$HEARTBEAT_URL" ] && { echo "BETTERSTACK_HEARTBEAT_URL not set; skipping"; exit 0; }
+          curl -sf "$HEARTBEAT_URL" > /dev/null || echo "::warning::heartbeat ping failed"


### PR DESCRIPTION
## problem

the daily fetch workflow has no liveness signal independent of the repo itself: if the cron is disabled, the workflow file breaks, or GitHub stops scheduling it, nothing is left alive to report a failure (the Axiom telemetry step only reports runs that happen).

## change

ping a Better Stack heartbeat (`BETTERSTACK_HEARTBEAT_URL` repo secret, already set) as the final step on successful runs only; a missing secret skips silently. the heartbeat expects one ping per day with a 6 hour grace window.

## verification

yaml lints clean; the step degrades to a workflow warning when the ping fails.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NDMk7xWhWuMx4HIy5dZCt8MYOxD33Gc-vRNrO17GpIyRGjPXGXMMCANJvS8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->