### PR TITLE
fix(web): stop embedding the full catalog in the compare page shell

### DIFF
--- a/apps/web/app/api/compare-models/route.ts
+++ b/apps/web/app/api/compare-models/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { allModels, getProvider } from "@/lib/data";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const keys = (searchParams.get("ids") ?? "")
+    .split(",")
+    .map((k) => k.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+
+  const models: Record<string, unknown> = {};
+  for (const key of keys) {
+    const m = allModels.find(
+      (model) => !model.alias && `${model.provider}/${model.id}` === key,
+    );
+    if (!m) continue;
+    const p = getProvider(m.provider);
+    const creator = m.created_by !== m.provider ? getProvider(m.created_by) : p;
+    models[key] = {
+      id: m.id,
+      name: m.name,
+      provider: m.provider,
+      created_by: m.created_by,
+      family: m.family,
+      status: m.status,
+      model_type: m.model_type,
+      release_date: m.release_date,
+      context_window: m.context_window,
+      max_context_window: m.max_context_window,
+      max_output_tokens: m.max_output_tokens,
+      max_input_tokens: m.max_input_tokens,
+      knowledge_cutoff: m.knowledge_cutoff,
+      reasoning_tokens: m.reasoning_tokens,
+      performance: m.performance,
+      reasoning: m.reasoning,
+      speed: m.speed,
+      capabilities: m.capabilities,
+      modalities: m.modalities,
+      pricing: m.pricing,
+      tools: m.tools,
+      endpoints: m.endpoints,
+      providerName: p?.name ?? m.provider,
+      providerIcon: p?.icon,
+      creatorName: creator?.name ?? m.created_by,
+      creatorIcon: creator?.icon,
+    };
+  }
+
+  return NextResponse.json(
+    { models },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
+}

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { ModelCompare } from "@/components/shared/model-compare";
 import { PageHeader } from "@/components/ui/page-header";
-import { allModels, getProvider } from "@/lib/data";
+import { allModels } from "@/lib/data";
 
 export const metadata: Metadata = {
   title: "Compare Models",
@@ -12,18 +12,7 @@ export const metadata: Metadata = {
 export default function ComparePage() {
   const models = allModels
     .filter((m) => !m.alias)
-    .map((m) => {
-      const p = getProvider(m.provider);
-      const creator =
-        m.created_by !== m.provider ? getProvider(m.created_by) : p;
-      return {
-        ...m,
-        providerName: p?.name ?? m.provider,
-        providerIcon: p?.icon,
-        creatorName: creator?.name ?? m.created_by,
-        creatorIcon: creator?.icon,
-      };
-    });
+    .map((m) => ({ id: m.id, name: m.name, provider: m.provider }));
 
   const aliases: Record<string, string> = {};
   for (const m of allModels) {

--- a/apps/web/components/shared/model-compare.tsx
+++ b/apps/web/components/shared/model-compare.tsx
@@ -28,7 +28,7 @@ import {
   Zap,
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { ModelPicker } from "@/components/shared/model-picker";
 import { ProviderIcon } from "@/components/shared/provider-icon";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -72,6 +72,12 @@ interface CompareModel {
   tools?: string[];
   endpoints?: string[];
   [key: string]: unknown;
+}
+
+interface CompareListModel {
+  id: string;
+  name: string;
+  provider: string;
 }
 
 function CompareRow({
@@ -225,22 +231,57 @@ function CompareInner({
   models,
   aliases,
 }: {
-  models: CompareModel[];
+  models: CompareListModel[];
   aliases: Record<string, string>;
 }) {
   const searchParams = useSearchParams();
+  const [details, setDetails] = useState<Record<string, CompareModel | null>>(
+    {},
+  );
 
   const rawA = searchParams.get("a");
   const rawB = searchParams.get("b");
   const modelA = rawA ? (aliases[rawA] ?? rawA) : null;
   const modelB = rawB ? (aliases[rawB] ?? rawB) : null;
 
-  const a = modelA
-    ? models.find((m) => `${m.provider}/${m.id}` === modelA)
-    : null;
-  const b = modelB
-    ? models.find((m) => `${m.provider}/${m.id}` === modelB)
-    : null;
+  useEffect(() => {
+    const missing = [modelA, modelB].filter(
+      (key): key is string => key != null && details[key] === undefined,
+    );
+    if (missing.length === 0) return;
+    let cancelled = false;
+    const markFailed = () => {
+      if (cancelled) return;
+      setDetails((prev) => {
+        const next = { ...prev };
+        for (const key of missing) next[key] ??= null;
+        return next;
+      });
+    };
+    fetch(`/api/compare-models?ids=${encodeURIComponent(missing.join(","))}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        return res.json();
+      })
+      .then((data: { models: Record<string, CompareModel> }) => {
+        if (cancelled) return;
+        setDetails((prev) => {
+          const next = { ...prev };
+          for (const key of missing) next[key] = data.models[key] ?? null;
+          return next;
+        });
+      })
+      .catch(markFailed);
+    return () => {
+      cancelled = true;
+    };
+  }, [modelA, modelB, details]);
+
+  const a = modelA ? details[modelA] : null;
+  const b = modelB ? details[modelB] : null;
+  const loading =
+    (modelA != null && details[modelA] === undefined) ||
+    (modelB != null && details[modelB] === undefined);
 
   function setModels(aKey: string | null, bKey: string | null) {
     const params = new URLSearchParams();
@@ -479,7 +520,7 @@ function CompareInner({
         </div>
       ) : (
         <div className="text-muted-foreground py-16 text-center text-sm text-balance">
-          Select two models to compare
+          {loading ? "Loading comparison…" : "Select two models to compare"}
         </div>
       )}
     </div>
@@ -490,7 +531,7 @@ export function ModelCompare({
   models,
   aliases,
 }: {
-  models: CompareModel[];
+  models: CompareListModel[];
   aliases: Record<string, string>;
 }) {
   return (

--- a/apps/web/components/shared/model-picker.tsx
+++ b/apps/web/components/shared/model-picker.tsx
@@ -11,8 +11,6 @@ interface PickerModel {
   id: string;
   name: string;
   provider: string;
-  providerName: string;
-  providerIcon?: string;
 }
 
 function toIconProp(icon?: string) {
@@ -43,7 +41,8 @@ export function ModelPicker({
 
   const filtered = query
     ? multiSearch(models, query, {
-        target: (m) => `${m.providerName} ${m.name} ${m.id}`,
+        target: (m) =>
+          `${getProvider(m.provider)?.name ?? m.provider} ${m.name} ${m.id}`,
         bonus: (m) =>
           PROVIDER_TYPE_TIER[getProvider(m.provider)?.type ?? "direct"] ?? 0,
         limit: 30,
@@ -90,7 +89,7 @@ export function ModelPicker({
         {current ? (
           <span className="text-foreground flex min-w-0 items-center gap-2 truncate">
             <ProviderIcon
-              provider={toIconProp(current.providerIcon)}
+              provider={toIconProp(getProvider(current.provider)?.icon)}
               size={14}
             />
             {current.name}
@@ -144,7 +143,7 @@ export function ModelPicker({
                   )}
                 >
                   <ProviderIcon
-                    provider={toIconProp(m.providerIcon)}
+                    provider={toIconProp(getProvider(m.provider)?.icon)}
                     size={13}
                   />
                   <div className="min-w-0 flex-1">


### PR DESCRIPTION
## problem

`/compare` serves 502 `FALLBACK_BODY_TOO_LARGE` on every cache MISS (crawlers walking unique `?a=` params hit it constantly; ~100 x 502 in 6h, driving the Axiom "Vercel long-tail 5xx" monitor). the prerendered shell embedded the full catalog: every model object spread whole into client props, each row carrying its provider's entire inline SVG. the built `compare.html` weighed 23.2MB, past Vercel's fallback body limit.

## root cause

the compare view only ever needs full data for the two selected models, but the page shipped all ~8000 models' full projections (plus 8000 duplicated provider SVGs) inside the static flight payload.

## change

- the page now ships only what the pickers need: `{id, name, provider}` per model plus the alias map; provider names and icons resolve client-side via the already-bundled `getProvider`.
- selected models fetch their full compare projection at runtime from a new same-origin `/api/compare-models?ids=` route handler (same pattern as `/api/search`, same build = zero data drift), edge-cached with `s-maxage=3600`.
- `ModelCompare` resolves selections from fetched state with a loading message; unknown ids degrade to the picker hint.

`compare.html` drops 23.2MB → 0.95MB (-96%).

## verification

`pnpm --filter web build` green (route table: `/compare` static, `/api/compare-models` dynamic); artifact sizes measured before/after; `next start` smoke: page 200, API returns both projections; browser pass on `/compare?a=xai/grok-4.6&b=openai/gpt-5.2` renders the full comparison table with icons, pricing, and capability rows.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qCASb84py9K2RRJx-SbljAJKLvjIVYEhxcfK_DAnk5zSISVbl_H_1Guv1Hg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->