### PR TITLE
ci: keep telemetry failures out of the fetch job status

### DIFF
--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -183,8 +183,12 @@ jobs:
           JOB_STATUS: ${{ job.status }}
         run: |
           [ -z "$AXIOM_TOKEN" ] && { echo "AXIOM_TOKEN not set; skipping"; exit 0; }
-          LAST_DATA_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits?path=packages/data/providers&sha=main&per_page=1" --jq '.[0].commit.committer.date')
-          AGE_HOURS=$(( ( $(date +%s) - $(date -d "$LAST_DATA_COMMIT" +%s) ) / 3600 ))
+          LAST_DATA_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits?path=packages/data/providers&sha=main&per_page=1" --jq '.[0].commit.committer.date' 2>/dev/null) || LAST_DATA_COMMIT=""
+          if [ -n "$LAST_DATA_COMMIT" ] && TS=$(date -d "$LAST_DATA_COMMIT" +%s 2>/dev/null); then
+            AGE_HOURS=$(( ( $(date +%s) - TS ) / 3600 ))
+          else
+            AGE_HOURS=-1
+          fi
           FAILED_JSON="[]"
           FAILED_COUNT=0
           if [ -f "$GITHUB_WORKSPACE/fetch-failures.txt" ]; then


### PR DESCRIPTION
## problem

the telemetry step runs under the workflow's fail-fast shell: a GitHub API outage, empty commit list, or date parse failure exits the `if: always()` step non-zero and marks the whole fetch job failed, contradicting the step's warning-only degradation design (flagged by review on #103).

## change

guard the freshness computation: a failed `gh api` or unparseable date degrades to `dataAgeHours: -1` ("unknown") instead of killing the step. `-1` can never false-trigger the planned `> 48h` staleness monitor.

## verification

yaml lints clean; the ingest call already degrades to a workflow warning.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nthDSjz7CaPcLoHbzIHlcd_xhOMs7N8B9FB7sZTo-HlFQP94e3s9rupeSok?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->