### PR TITLE
ci: drop the axiom pipeline telemetry

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -72,22 +72,3 @@ jobs:
           git add packages/data/changes/changes.jsonl
           git commit -m "data(changes): update"
           git push
-
-      # Each appended change record lands in Axiom trimmed to the monitorable
-      # shape: changed field names plus pricing before/after, never the long
-      # description diffs.
-      - name: Report changes to Axiom
-        if: steps.detect.outputs.changed == 'true'
-        env:
-          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
-        run: |
-          [ -z "$AXIOM_TOKEN" ] && { echo "AXIOM_TOKEN not set; skipping"; exit 0; }
-          git diff HEAD~1 -- packages/data/changes/changes.jsonl | grep '^+{' | sed 's/^+//' | \
-            jq -c '{msg:"model.change", _time:.ts, provider, model, action, commit, fields:((.changes // {}) | keys), pricing_from_input:(getpath(["changes","pricing","from","input"])), pricing_from_output:(getpath(["changes","pricing","from","output"])), pricing_to_input:(getpath(["changes","pricing","to","input"])), pricing_to_output:(getpath(["changes","pricing","to","output"]))} | with_entries(select(.value != null))' \
-            > /tmp/axiom-changes.ndjson || true
-          [ -s /tmp/axiom-changes.ndjson ] || { echo "no change lines to report"; exit 0; }
-          curl -sf -X POST "https://api.axiom.co/v1/datasets/modelpedia-pipeline/ingest" \
-            -H "Authorization: Bearer $AXIOM_TOKEN" \
-            -H "Content-Type: application/x-ndjson" \
-            --data-binary @/tmp/axiom-changes.ndjson > /dev/null \
-            || echo "::warning::axiom ingest failed"

--- a/.github/workflows/fetch-models.yml
+++ b/.github/workflows/fetch-models.yml
@@ -171,46 +171,6 @@ jobs:
               --body "$BODY"
           fi
 
-      # Freshness and scrape health land in Axiom so a stale data PR or a
-      # broken provider raises an alert instead of hiding in a green run.
-      # dataAgeHours comes from the GitHub API because the checkout is shallow
-      # and the branch step above rewrites local history.
-      - name: Report pipeline telemetry to Axiom
-        if: always()
-        env:
-          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          [ -z "$AXIOM_TOKEN" ] && { echo "AXIOM_TOKEN not set; skipping"; exit 0; }
-          LAST_DATA_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits?path=packages/data/providers&sha=main&per_page=1" --jq '.[0].commit.committer.date' 2>/dev/null) || LAST_DATA_COMMIT=""
-          if [ -n "$LAST_DATA_COMMIT" ] && TS=$(date -d "$LAST_DATA_COMMIT" +%s 2>/dev/null); then
-            AGE_HOURS=$(( ( $(date +%s) - TS ) / 3600 ))
-          else
-            AGE_HOURS=-1
-          fi
-          FAILED_JSON="[]"
-          FAILED_COUNT=0
-          if [ -f "$GITHUB_WORKSPACE/fetch-failures.txt" ]; then
-            FAILED_JSON=$(jq -R . "$GITHUB_WORKSPACE/fetch-failures.txt" | jq -cs .)
-            FAILED_COUNT=$(wc -l < "$GITHUB_WORKSPACE/fetch-failures.txt" | tr -d ' ')
-          fi
-          {
-            jq -cn --arg runId "$GITHUB_RUN_ID" --arg status "$JOB_STATUS" \
-              --argjson failedProviders "$FAILED_JSON" --argjson failedCount "$FAILED_COUNT" \
-              --argjson dataAgeHours "$AGE_HOURS" \
-              '{msg:"pipeline.run", runId:$runId, status:$status, failedProviders:$failedProviders, failedCount:$failedCount, dataAgeHours:$dataAgeHours}'
-            for f in packages/data/providers/*/_seen.json; do
-              p=$(basename "$(dirname "$f")")
-              jq -c --arg provider "$p" '{msg:"pipeline.provider", provider:$provider, models:.count, seenDate:.date}' "$f"
-            done
-          } > /tmp/axiom-events.ndjson
-          curl -sf -X POST "https://api.axiom.co/v1/datasets/modelpedia-pipeline/ingest" \
-            -H "Authorization: Bearer $AXIOM_TOKEN" \
-            -H "Content-Type: application/x-ndjson" \
-            --data-binary @/tmp/axiom-events.ndjson > /dev/null \
-            || echo "::warning::axiom ingest failed"
-
       # A successful daily run pings Better Stack; a run that stops arriving
       # (cron disabled, workflow broken, repo archived) raises an incident even
       # when nothing is left alive to report a failure.


### PR DESCRIPTION
## problem

the axiom pipeline telemetry (#103, #107) monitored the symptom: it would page when the daily data PR sat unmerged past 48h, but a human still had to go merge it. the direction is now to remove the human step entirely (auto-merge logic, likely via rupic, with pricing sanity moved into `validate.ts` as a merge gate), which makes the staleness monitoring layer moot before its dataset was ever provisioned.

## change

remove both axiom reporting steps (`pipeline.run`/`pipeline.provider` in fetch-models, `model.change` in changes). the Better Stack heartbeat stays: it answers "is the pipeline alive at all", which auto-merge logic depends on too and cannot report on its own.

## verification

yaml lints clean; both steps were no-ops in production anyway (the `AXIOM_TOKEN` secret was never provisioned, so every run skipped them).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lJsHAO2foPtbihNjzVJe2QfqV859TGAmFxN3sYqDFSX6bSvAKdOQca4pW-w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->