### PR TITLE
ci: annotate axiom with each deploy

### DIFF
--- a/.github/workflows/axiom-annotation.yaml
+++ b/.github/workflows/axiom-annotation.yaml
@@ -1,0 +1,45 @@
+name: Axiom deploy annotation
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: axiom-annotation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  annotate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Marks the deploy on every Axiom chart this repository's telemetry lands
+      # on, so a latency or error step can be lined up against what shipped.
+      - name: Record the deploy
+        env:
+          AXIOM_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AXIOM_TOKEN:-}" ]; then
+            echo "AXIOM_API_TOKEN is not set; skipping the annotation."
+            exit 0
+          fi
+          jq -nc \
+            --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg title "${REPOSITORY}@${SHA:0:7}" \
+            --arg description "${COMMIT_MESSAGE%%$'\n'*}" \
+            --arg url "${COMMIT_URL}" \
+            --argjson datasets '["cloudflare","traces","vercel"]' \
+            '{type: "deploy", time: $time, title: $title, description: $description, url: $url, datasets: $datasets}' \
+          | curl --fail-with-body --silent --show-error \
+              -X POST https://api.axiom.co/v2/annotations \
+              -H "Authorization: Bearer ${AXIOM_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data @-


### PR DESCRIPTION
posts a `deploy` annotation to axiom on every push to main, so a latency or error step on a dashboard lines up against what shipped instead of being matched to a timestamp by hand.

no action dependencies, just curl and jq. the job skips itself when `AXIOM_API_TOKEN` is unset, so a fork or a repo without the secret stays green.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Aj-PQ0AZTk8oUkK3Ep2_7M4nG4wgJRn4PgO2R5ygkNTJR2d1wRraEj7Zz8o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->